### PR TITLE
Filter out alcohol and caffeine from nutrition improvements display -…

### DIFF
--- a/src/components/NutriGap/AllNutrientsView.tsx
+++ b/src/components/NutriGap/AllNutrientsView.tsx
@@ -99,6 +99,12 @@ export default function AllNutrientsView({
   const filteredAndSortedNutrients = useMemo(() => {
     let result = Object.values(adjustedGaps);
 
+    // Filter out alcohol and caffeine from the main nutrition view
+    // These should be in notes section, not nutrition improvements
+    result = result.filter(nutrient => 
+      nutrient.name !== 'Alcohol(d)' && nutrient.name !== 'Caffeine'
+    );
+
     // Apply search filter
     if (searchTerm) {
       const lowerSearch = searchTerm.toLowerCase();

--- a/src/components/NutriRecommend/NutriRecommendService.ts
+++ b/src/components/NutriRecommend/NutriRecommendService.ts
@@ -66,8 +66,15 @@ export const NutriRecommendService = {
     }
     
     // Get missing nutrients from the potentially adjusted result
+    // Exclude alcohol and caffeine from nutrition improvements display
     const missingNutrientsArray = Object.entries(adjustedResult.nutrient_gaps)
-      .filter(([_, info]) => info.recommended_intake > 0 && info.current_intake / info.recommended_intake < 1)
+      .filter(([name, info]) => {
+        // Exclude alcohol and caffeine from nutrition improvements
+        if (name === 'Alcohol(d)' || name === 'Caffeine') {
+          return false;
+        }
+        return info.recommended_intake > 0 && info.current_intake / info.recommended_intake < 1;
+      })
       .map(([name, info]) => {
         const percentage = (info.current_intake / info.recommended_intake) * 100;
         return {
@@ -625,8 +632,15 @@ export const NutriRecommendService = {
     }
     
     // Get missing nutrients from the potentially adjusted result
+    // Exclude alcohol and caffeine from nutrition improvements display
     const missingNutrientsArray = Object.entries(adjustedResult.nutrient_gaps)
-      .filter(([_, info]) => info.recommended_intake > 0 && info.current_intake / info.recommended_intake < 1)
+      .filter(([name, info]) => {
+        // Exclude alcohol and caffeine from nutrition improvements
+        if (name === 'Alcohol(d)' || name === 'Caffeine') {
+          return false;
+        }
+        return info.recommended_intake > 0 && info.current_intake / info.recommended_intake < 1;
+      })
       .map(([name, info]) => {
         const percentage = (info.current_intake / info.recommended_intake) * 100;
         return {


### PR DESCRIPTION
… Exclude Alcohol(d) and Caffeine from nutrition recommendations in NutriRecommendService - Filter alcohol and caffeine from AllNutrientsView component - These nutrients should appear in notes section, not nutrition improvements - Fixes issue where alcohol and caffeine were incorrectly shown as nutrition gaps

## What and why are you proposing this feature/fix?


## What tests did you do to test this feature/fix?
 

## Notes
- Try to use `[Fix]`, `[Feature]`, `[Refactor]`, `[Release]`, `[Hotfix]` in the title
- Add some explanation and difference between the new and the current version we have
- Adding pictures can be good too!
<img width="875" alt="image" src="https://github.com/user-attachments/assets/5f645c57-532d-4821-bb30-c604a69c4466" />
<img width="864" alt="image" src="https://github.com/user-attachments/assets/e31fed42-bcb2-491b-9195-462e664fa1bb" />
<img width="658" alt="image" src="https://github.com/user-attachments/assets/64548ab2-cc61-4cb0-9e8e-aaa0f865f42e" />
