### PR TITLE
fix: Disable image optimization to prevent 400 errors on production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,8 +6,7 @@ const withNextIntl = require('next-intl/plugin')(
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-
-    unoptimized: process.env.NODE_ENV === 'development',
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
- Set images.unoptimized: true for all environments
- Fixes logo and static images 400 Bad Request errors
- Images will be served directly without Next.js optimization

## What and why are you proposing this feature/fix?


## What tests did you do to test this feature/fix?
 

## Notes
- Try to use `[Fix]`, `[Feature]`, `[Refactor]`, `[Release]`, `[Hotfix]` in the title
- Add some explanation and difference between the new and the current version we have
- Adding pictures can be good too!
